### PR TITLE
Quality of life changes

### DIFF
--- a/ModelFactories.Tests/Unit/ModelFactoryTests.cs
+++ b/ModelFactories.Tests/Unit/ModelFactoryTests.cs
@@ -121,6 +121,16 @@ public class ModelFactoryTests
         model.Title.Should().Be("foo");
     }
 
+    [Fact]
+    public void ItCanCreateModelWithRawValue()
+    {
+        var model = new PostFactory()
+            .Property(p => p.Title, "::title::")
+            .Create();
+
+        model.Title.Should().Be("::title::");
+    }
+
     #endregion
 
     #region Related Factories

--- a/ModelFactories.Tests/Unit/ModelFactoryTests.cs
+++ b/ModelFactories.Tests/Unit/ModelFactoryTests.cs
@@ -21,7 +21,7 @@ public class ModelFactoryTests
     public void ItCanCreateManyModels()
     {
         var models = new AuthorFactory()
-            .CreateMany(2);
+            .Create(2);
 
         models.Should().BeOfType<List<Author>>();
         models.Should().HaveCount(2);

--- a/ModelFactories/ModelFactory.cs
+++ b/ModelFactories/ModelFactory.cs
@@ -77,6 +77,17 @@ public abstract class ModelFactory<T> where T : class, new()
         return this;
     }
 
+    public ModelFactory<T> Property<TProperty>(
+        Expression<Func<T, TProperty>> propertyExpression,
+        TProperty value
+    )
+    {
+        var propertyName = PropertyName(propertyExpression);
+        _definitions.Add(new PropertyDefinition<TProperty>(propertyName, () => value));
+
+        return this;
+    }
+
     public ModelFactory<T> With<TRelated, TFactory>(Expression<Func<T, TRelated?>> property)
         where TRelated : class, new()
         where TFactory : ModelFactory<TRelated>, new()

--- a/ModelFactories/ModelFactory.cs
+++ b/ModelFactories/ModelFactory.cs
@@ -38,6 +38,11 @@ public abstract class ModelFactory<T> where T : class, new()
         return GetModel();
     }
 
+    public List<T> Create(uint count)
+    {
+        return CreateMany(count);
+    }
+
     public List<T> CreateMany(uint count = 1)
     {
         var list = new List<T>();

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ public class PostFactory : ModelFactory<Post>
         Property(p => p.Id, () => Guid.NewGuid())
             .Property(p => p.Title, () => "Post title")
             .Property(p => p.Body, () => "Lorem ipsum")
+            // You can also use raw values instead of callbacks:
+            //.Property(p => p.Title, "Hardcoded title")
             .Property(p => p.CreatedAt, () => DateTime.Now);
     }
 }


### PR DESCRIPTION
* You can now call create with an uint parameter as an alias for CreateMany, i.e. `new PostFactory().Create(4)`
* You can now give the `Property` method static values, i.e. `new PostFactory().Property(p => p.Title, "Hardcoded Title")` instead of wrapping it in an anonymous function