### PR TITLE
Bug/create many overwrites all created models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.3
+## Bugs
+Fixed a bug where using batch creation (Create(int) or CreateMany(int))
+didn't generate new values for each created model
+
 # 0.2.2
 ## Bugs
 Fixed a bug where calling .Property() sometimes would not override the property.

--- a/ModelFactories.Tests/Factories/ModelWithRandomValueFactory.cs
+++ b/ModelFactories.Tests/Factories/ModelWithRandomValueFactory.cs
@@ -1,0 +1,13 @@
+using ModelFactories.Tests.Models;
+
+namespace ModelFactories.Tests.Factories;
+
+public class ModelWithRandomValueFactory : ModelFactory<ModelWithRandomValue>
+{
+    private Random random = new Random();
+
+    protected override void Definition()
+    {
+        Property(m => m.Value, () => random.Next(Int32.MinValue, Int32.MaxValue));
+    }
+}

--- a/ModelFactories.Tests/Models/ModelWithRandomValue.cs
+++ b/ModelFactories.Tests/Models/ModelWithRandomValue.cs
@@ -1,0 +1,6 @@
+namespace ModelFactories.Tests.Models;
+
+public class ModelWithRandomValue
+{
+    public int Value { get; set; }
+}

--- a/ModelFactories.Tests/Unit/StateTest.cs
+++ b/ModelFactories.Tests/Unit/StateTest.cs
@@ -7,139 +7,149 @@ namespace ModelFactories.Tests;
 
 public class StateTest
 {
-	[Fact]
-	public void ItCanCreateModel()
-	{
-		var model = new AuthorFactory().Create();
+    [Fact]
+    public void ItCanCreateModel()
+    {
+        var model = new AuthorFactory().Create();
 
-		model.Name.Should().Be("foo");
-	}
+        model.Name.Should().Be("foo");
+    }
 
-	[Fact]
-	public void ItCanCreateManyModels()
-	{
-		var models = new AuthorFactory()
-			.Create(2);
+    [Fact]
+    public void ItCanCreateManyModels()
+    {
+        var models = new AuthorFactory()
+            .Create(2);
 
-		models.Should().BeOfType<List<Author>>();
-		models.Should().HaveCount(2);
-	}
+        models.Should().BeOfType<List<Author>>();
+        models.Should().HaveCount(2);
+    }
 
-	[Fact]
-	public void ItUsesStateWhenCreatingMany()
-	{
-		var models = new PostFactory()
-			.Published()
-			.WithFooTitle()
-			.CreateMany(2);
+    [Fact]
+    public void ItUsesStateWhenCreatingMany()
+    {
+        var models = new PostFactory()
+            .Published()
+            .WithFooTitle()
+            .CreateMany(2);
 
-		models.Should().BeOfType<List<Post>>();
-		models.Should().HaveCount(2);
-		models.ForEach(p =>
-		{
-			p.Title.Should().Be("foo");
-			p.PublishedFrom.Should().NotBeNull();
-		});
-	}
+        models.Should().BeOfType<List<Post>>();
+        models.Should().HaveCount(2);
+        models.ForEach(p =>
+        {
+            p.Title.Should().Be("foo");
+            p.PublishedFrom.Should().NotBeNull();
+        });
+    }
 
-	[Fact]
-	public void ItCanOverwriteProp()
-	{
-		var model = new AuthorFactory()
-			.Property(a => a.Name, () => "bar")
-			.Create();
+    [Fact]
+    public void ItCanOverwriteProp()
+    {
+        var model = new AuthorFactory()
+            .Property(a => a.Name, () => "bar")
+            .Create();
 
-		model.Name.Should().Be("bar");
-	}
+        model.Name.Should().Be("bar");
+    }
 
-	[Fact]
-	public void ItCanOverwriteMultipleProps()
-	{
-		Guid id = Guid.NewGuid();
+    [Fact]
+    public void ItCanOverwriteMultipleProps()
+    {
+        Guid id = Guid.NewGuid();
 
-		var model = new AuthorFactory()
-			.Property(a => a.Id, () => id)
-			.Property(a => a.Name, () => "baz")
-			.Create();
+        var model = new AuthorFactory()
+            .Property(a => a.Id, () => id)
+            .Property(a => a.Name, () => "baz")
+            .Create();
 
-		model.Id.Should().Be(id);
-		model.Name.Should().Be("baz");
-	}
+        model.Id.Should().Be(id);
+        model.Name.Should().Be("baz");
+    }
 
-	[Fact]
-	public void ItCanOverwritePropertyUsingModel()
-	{
-		var model = new AuthorFactory()
-			.Property(a => a.Name, (model) => model.Id.ToString())
-			.Create();
+    [Fact]
+    public void ItCanOverwritePropertyUsingModel()
+    {
+        var model = new AuthorFactory()
+            .Property(a => a.Name, (model) => model.Id.ToString())
+            .Create();
 
-		model.Name.Should().Be(model.Id.ToString());
-	}
+        model.Name.Should().Be(model.Id.ToString());
+    }
 
-	[Fact]
-	public void GeneratingForNonWritablePropertyThrowsException()
-	{
-		Assert.Throws<PropIsReadOnlyException>(() =>
-		{
-			new AuthorFactory()
-				.Property(a => a.NotWritable, () => "foo")
-				.Create();
-		});
-	}
+    [Fact]
+    public void GeneratingForNonWritablePropertyThrowsException()
+    {
+        Assert.Throws<PropIsReadOnlyException>(() =>
+        {
+            new AuthorFactory()
+                .Property(a => a.NotWritable, () => "foo")
+                .Create();
+        });
+    }
 
-	[Fact]
-	public void ItCanUsePredefinedState()
-	{
-		var model = new PostFactory().Published().Create();
+    [Fact]
+    public void ItCanUsePredefinedState()
+    {
+        var model = new PostFactory().Published().Create();
 
-		model.PublishedFrom.Should().NotBeNull();
-	}
+        model.PublishedFrom.Should().NotBeNull();
+    }
 
-	[Fact]
-	public void ItCanCombineStateWithOverrides()
-	{
-		var model = new PostFactory()
-			.Published()
-			.Property(p => p.Title, () => "::title::")
-			.Create();
+    [Fact]
+    public void ItCanCombineStateWithOverrides()
+    {
+        var model = new PostFactory()
+            .Published()
+            .Property(p => p.Title, () => "::title::")
+            .Create();
 
-		model.PublishedFrom.Should().NotBeNull();
-		model.Title.Should().Be("::title::");
-	}
+        model.PublishedFrom.Should().NotBeNull();
+        model.Title.Should().Be("::title::");
+    }
 
-	[Fact]
-	public void ItCanCombineMultipleStates()
-	{
-		var model = new PostFactory()
-			.Published()
-			.WithFooTitle()
-			.Create();
+    [Fact]
+    public void ItCanCombineMultipleStates()
+    {
+        var model = new PostFactory()
+            .Published()
+            .WithFooTitle()
+            .Create();
 
-		model.PublishedFrom.Should().NotBeNull();
-		model.Title.Should().Be("foo");
-	}
+        model.PublishedFrom.Should().NotBeNull();
+        model.Title.Should().Be("foo");
+    }
 
-	[Fact]
-	public void ItCanCreateModelWithRawValue()
-	{
-		var model = new PostFactory()
-			.Property(p => p.Title, "::title::")
-			.Create();
+    [Fact]
+    public void ItCanCreateModelWithRawValue()
+    {
+        var model = new PostFactory()
+            .Property(p => p.Title, "::title::")
+            .Create();
 
-		model.Title.Should().Be("::title::");
-	}
+        model.Title.Should().Be("::title::");
+    }
 
-	[Fact]
-	public void ItCanOverrideDefinitionPropertiesWithModel()
-	{
-		// This tests a bug where if the Definition() method had a property which uses the created model,
-		// i.e. Property(p => p.PublishedFrom, model => model.CreatedAt),
-		// the Definition() one would be used even if overriding it with .Property outside
+    [Fact]
+    public void ItCanOverrideDefinitionPropertiesWithModel()
+    {
+        // This tests a bug where if the Definition() method had a property which uses the created model,
+        // i.e. Property(p => p.PublishedFrom, model => model.CreatedAt),
+        // the Definition() one would be used even if overriding it with .Property outside
 
-		var comment = new CommentFactory()
-			.Property(c => c.UpdatedAt, () => null)
-			.Create();
+        var comment = new CommentFactory()
+            .Property(c => c.UpdatedAt, () => null)
+            .Create();
 
-		comment.UpdatedAt.Should().BeNull();
-	}
+        comment.UpdatedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void ItGeneratesNewValuesForEachModelGenerated()
+    {
+        var items = new ModelWithRandomValueFactory().CreateMany(2);
+        var values = items.Select(i => i.Value).ToList();
+
+        var isUnique = values.Distinct().Count() == items.Count;
+        isUnique.Should().BeTrue();
+    }
 }

--- a/ModelFactories/ModelFactories.csproj
+++ b/ModelFactories/ModelFactories.csproj
@@ -6,15 +6,15 @@
         <Nullable>enable</Nullable>
 
         <PackageId>ModelFactories</PackageId>
-        <Version>0.2.2</Version>
+        <Version>0.2.3</Version>
         <Authors>Larsmbergvall</Authors>
-        <AssemblyVersion>0.2.2</AssemblyVersion>
+        <AssemblyVersion>0.2.3</AssemblyVersion>
 
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/larsmbergvall/model-factories</RepositoryUrl>
-		
+
     </PropertyGroup>
 
     <ItemGroup>

--- a/ModelFactories/ModelFactory.cs
+++ b/ModelFactories/ModelFactory.cs
@@ -6,232 +6,221 @@ namespace ModelFactories;
 
 public abstract class ModelFactory<T> where T : class, new()
 {
-	private Dictionary<string, IPropertyDefinition> _definitions = new();
-	private Dictionary<string, IPropertyDefinition> _definitionsWithModel = new();
-	private T? _model = null;
-	private Dictionary<string, IRelatedDefinition> _relatedFactories = new();
-	private List<Func<T, T>> _afterCallbacks = new();
+    private List<Func<T, T>> _afterCallbacks = new();
+    private Dictionary<string, IPropertyDefinition> _definitions = new();
+    private Dictionary<string, IPropertyDefinition> _definitionsWithModel = new();
+    private T? _model = null;
+    private Dictionary<string, IRelatedDefinition> _relatedFactories = new();
 
-	public ModelFactory()
-	{
-		Configure();
-	}
+    public ModelFactory()
+    {
+        Configure();
+    }
 
-	protected abstract void Definition();
+    protected abstract void Definition();
 
-	public T Create()
-	{
-		foreach (var (key, prop) in _definitions)
-		{
-			ApplyProperty(prop);
-		}
+    public T Create()
+    {
+        var model = new T();
 
-		foreach (var (key, prop) in _definitionsWithModel)
-		{
-			ApplyProperty(prop, true);
-		}
+        foreach (var (key, prop) in _definitions)
+        {
+            ApplyProperty(model, prop);
+        }
 
-		foreach (var (key, related) in _relatedFactories)
-		{
-			CreateRelated(related);
-		}
+        foreach (var (key, prop) in _definitionsWithModel)
+        {
+            ApplyProperty(model, prop, true);
+        }
 
-		return ExecuteAfterCallbacks(GetModel());
-	}
+        foreach (var (key, related) in _relatedFactories)
+        {
+            CreateRelated(model, related);
+        }
 
-	public List<T> Create(uint count)
-	{
-		return CreateMany(count);
-	}
+        return ExecuteAfterCallbacks(model);
+    }
 
-	public List<T> CreateMany(uint count = 1)
-	{
-		var list = new List<T>();
+    public List<T> Create(uint count)
+    {
+        return CreateMany(count);
+    }
 
-		for (int i = 0; i < count; i++)
-		{
-			list.Add(ExecuteAfterCallbacks(Create()));
-		}
+    public List<T> CreateMany(uint count = 1)
+    {
+        var list = new List<T>();
 
-		return list;
-	}
+        for (int i = 0; i < count; i++)
+        {
+            list.Add(Create());
+        }
 
-	public ModelFactory<T> Property<TProperty>(
-		Expression<Func<T, TProperty>> propertyExpression,
-		Func<TProperty> callback
-	)
-	{
-		var propertyName = PropertyName(propertyExpression);
-		RemovePropertyKeysIfExists(propertyName);
-		_definitions.Add(propertyName, new PropertyDefinition<TProperty>(propertyName, callback));
+        return list;
+    }
 
-		return this;
-	}
+    public ModelFactory<T> Property<TProperty>(
+        Expression<Func<T, TProperty>> propertyExpression,
+        Func<TProperty> callback
+    )
+    {
+        var propertyName = PropertyName(propertyExpression);
+        RemovePropertyKeysIfExists(propertyName);
+        _definitions.Add(propertyName, new PropertyDefinition<TProperty>(propertyName, callback));
 
-	public ModelFactory<T> Property<TProperty>(
-		Expression<Func<T, TProperty>> propertyExpression,
-		Func<T, TProperty> callback
-	)
-	{
-		var propertyName = PropertyName(propertyExpression);
-		RemovePropertyKeysIfExists(propertyName);
-		_definitionsWithModel.Add(propertyName, new PropertyDefinitionWithModel<T, TProperty>(propertyName, callback));
+        return this;
+    }
 
-		return this;
-	}
+    public ModelFactory<T> Property<TProperty>(
+        Expression<Func<T, TProperty>> propertyExpression,
+        Func<T, TProperty> callback
+    )
+    {
+        var propertyName = PropertyName(propertyExpression);
+        RemovePropertyKeysIfExists(propertyName);
+        _definitionsWithModel.Add(propertyName, new PropertyDefinitionWithModel<T, TProperty>(propertyName, callback));
 
-	public ModelFactory<T> Property<TProperty>(
-		Expression<Func<T, TProperty>> propertyExpression,
-		TProperty value
-	)
-	{
-		var propertyName = PropertyName(propertyExpression);
-		RemovePropertyKeysIfExists(propertyName);
-		_definitions.Add(propertyName, new PropertyDefinition<TProperty>(propertyName, () => value));
+        return this;
+    }
 
-		return this;
-	}
+    public ModelFactory<T> Property<TProperty>(
+        Expression<Func<T, TProperty>> propertyExpression,
+        TProperty value
+    )
+    {
+        var propertyName = PropertyName(propertyExpression);
+        RemovePropertyKeysIfExists(propertyName);
+        _definitions.Add(propertyName, new PropertyDefinition<TProperty>(propertyName, () => value));
 
-	public ModelFactory<T> With<TRelated, TFactory>(Expression<Func<T, TRelated?>> property)
-		where TRelated : class, new()
-		where TFactory : ModelFactory<TRelated>, new()
-	{
-		var propertyName = PropertyName(property);
-		RemovePropertyKeysIfExists(propertyName);
+        return this;
+    }
 
-		_relatedFactories.Add(
-			propertyName,
-			new RelatedDefinition<TRelated, TFactory>(propertyName)
-		);
+    public ModelFactory<T> With<TRelated, TFactory>(Expression<Func<T, TRelated?>> property)
+        where TRelated : class, new()
+        where TFactory : ModelFactory<TRelated>, new()
+    {
+        var propertyName = PropertyName(property);
+        RemovePropertyKeysIfExists(propertyName);
 
-		return this;
-	}
+        _relatedFactories.Add(
+            propertyName,
+            new RelatedDefinition<TRelated, TFactory>(propertyName)
+        );
 
-	public ModelFactory<T> With<TRelated, TFactory>(Expression<Func<T, TRelated?>> property,
-		Func<TFactory, TRelated> callback)
-		where TRelated : class, new()
-		where TFactory : ModelFactory<TRelated>, new()
-	{
-		var propertyName = PropertyName(property);
-		RemovePropertyKeysIfExists(propertyName);
+        return this;
+    }
 
-		_relatedFactories.Add(
-			propertyName,
-			new RelatedDefinition<TRelated, TFactory>(propertyName, callback)
-		);
+    public ModelFactory<T> With<TRelated, TFactory>(Expression<Func<T, TRelated?>> property,
+        Func<TFactory, TRelated> callback)
+        where TRelated : class, new()
+        where TFactory : ModelFactory<TRelated>, new()
+    {
+        var propertyName = PropertyName(property);
+        RemovePropertyKeysIfExists(propertyName);
 
-		return this;
-	}
+        _relatedFactories.Add(
+            propertyName,
+            new RelatedDefinition<TRelated, TFactory>(propertyName, callback)
+        );
 
-	public ModelFactory<T> AfterCreate(Func<T, T> callback)
-	{
-		_afterCallbacks.Add(callback);
+        return this;
+    }
 
-		return this;
-	}
+    public ModelFactory<T> AfterCreate(Func<T, T> callback)
+    {
+        _afterCallbacks.Add(callback);
 
-	private T ExecuteAfterCallbacks(T model)
-	{
-		foreach (var callback in _afterCallbacks)
-		{
-			model = callback(model);
-		}
+        return this;
+    }
 
-		return model;
-	}
+    private T ExecuteAfterCallbacks(T model)
+    {
+        foreach (var callback in _afterCallbacks)
+        {
+            model = callback(model);
+        }
 
+        return model;
+    }
 
-	private T GetModel()
-	{
-		if (_model is null)
-		{
-			_model = new T();
-		}
+    private void ApplyProperty(T model, IPropertyDefinition propertyDefinition, bool withModel = false)
+    {
+        var reflection = model.GetType();
+        var prop = reflection.GetProperty(propertyDefinition.PropertyName);
 
-		return _model;
-	}
+        EnsurePropExistsAndIsWritable(propertyDefinition, prop, reflection);
 
-	private void ApplyProperty(IPropertyDefinition propertyDefinition, bool withModel = false)
-	{
-		var model = GetModel();
-		var reflection = model.GetType();
-		var prop = reflection.GetProperty(propertyDefinition.PropertyName);
+        if (withModel)
+        {
+            prop!.SetValue(model, propertyDefinition.Callback.DynamicInvoke(model));
+            return;
+        }
 
-		EnsurePropExistsAndIsWritable(propertyDefinition, prop, reflection);
+        prop!.SetValue(model, propertyDefinition.Callback.DynamicInvoke());
+    }
 
-		if (withModel)
-		{
-			prop!.SetValue(model, propertyDefinition.Callback.DynamicInvoke(model));
-			return;
-		}
+    private void CreateRelated(T model, IRelatedDefinition relatedDefinition)
+    {
+        var reflection = model.GetType();
+        var prop = reflection.GetProperty(relatedDefinition.PropertyName);
 
-		prop!.SetValue(model, propertyDefinition.Callback.DynamicInvoke());
-	}
+        EnsurePropExistsAndIsWritable(relatedDefinition, prop, reflection);
 
-	private void CreateRelated(IRelatedDefinition relatedDefinition)
-	{
-		var model = GetModel();
-		var reflection = model.GetType();
-		var prop = reflection.GetProperty(relatedDefinition.PropertyName);
+        prop!.SetValue(
+            model,
+            relatedDefinition.Callback.DynamicInvoke(relatedDefinition.CreateFactory.DynamicInvoke())
+        );
+    }
 
-		EnsurePropExistsAndIsWritable(relatedDefinition, prop, reflection);
+    private void Configure()
+    {
+        Definition();
+    }
 
-		prop!.SetValue(
-			model,
-			relatedDefinition.Callback.DynamicInvoke(relatedDefinition.CreateFactory.DynamicInvoke())
-		);
-	}
+    /// <summary>
+    /// Removes a key from both definition dictionaries. This is to ensure there is only ever one
+    /// definition for a given property
+    /// </summary>
+    /// <param name="key"></param>
+    private void RemovePropertyKeysIfExists(string key)
+    {
+        _definitions.Remove(key);
+        _definitionsWithModel.Remove(key);
+        _relatedFactories.Remove(key);
+    }
 
-	private void Configure()
-	{
-		Definition();
-	}
+    private static void EnsurePropExistsAndIsWritable(IPropertyDefinition definition, PropertyInfo? propInfo, Type type)
+    {
+        if (propInfo is null)
+        {
+            throw new ModelFactoryException($"Property {definition.PropertyName} does not exist on {type.FullName}");
+        }
 
-	/// <summary>
-	/// Removes a key from both definition dictionaries. This is to ensure there is only ever one
-	/// definition for a given property
-	/// </summary>
-	/// <param name="key"></param>
-	private void RemovePropertyKeysIfExists(string key)
-	{
-		_definitions.Remove(key);
-		_definitionsWithModel.Remove(key);
-		_relatedFactories.Remove(key);
-	}
+        if (!propInfo.CanWrite)
+        {
+            throw new PropIsReadOnlyException(definition, type);
+        }
+    }
 
-	private static void EnsurePropExistsAndIsWritable(IPropertyDefinition definition, PropertyInfo? propInfo, Type type)
-	{
-		if (propInfo is null)
-		{
-			throw new ModelFactoryException($"Property {definition.PropertyName} does not exist on {type.FullName}");
-		}
+    private static void EnsurePropExistsAndIsWritable(IRelatedDefinition definition, PropertyInfo? propInfo, Type type)
+    {
+        if (propInfo is null)
+        {
+            throw new ModelFactoryException($"Property {definition.PropertyName} does not exist on {type.FullName}");
+        }
 
-		if (!propInfo.CanWrite)
-		{
-			throw new PropIsReadOnlyException(definition, type);
-		}
-	}
+        if (!propInfo.CanWrite)
+        {
+            throw new PropIsReadOnlyException(definition, type);
+        }
+    }
 
-	private static void EnsurePropExistsAndIsWritable(IRelatedDefinition definition, PropertyInfo? propInfo, Type type)
-	{
-		if (propInfo is null)
-		{
-			throw new ModelFactoryException($"Property {definition.PropertyName} does not exist on {type.FullName}");
-		}
+    private static string PropertyName<TType, TReturn>(Expression<Func<TType, TReturn>> expression)
+    {
+        if (expression.Body is MemberExpression memberExpression)
+        {
+            return memberExpression.Member.Name;
+        }
 
-		if (!propInfo.CanWrite)
-		{
-			throw new PropIsReadOnlyException(definition, type);
-		}
-	}
-
-	private static string PropertyName<TType, TReturn>(Expression<Func<TType, TReturn>> expression)
-	{
-		if (expression.Body is MemberExpression memberExpression)
-		{
-			return memberExpression.Member.Name;
-		}
-
-		throw new ModelFactoryException("Could not extract name from expression");
-	}
+        throw new ModelFactoryException("Could not extract name from expression");
+    }
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Laravel [Model Factories](https://laravel.com/docs/eloquent-factories)
 
 This package is still in early development, so expect bugs and breaking changes :)
 
-[Changelog](CHANGELOG.md)
+**[Changelog](https://github.com/larsmbergvall/model-factories/blob/main/CHANGELOG.md)**
 
 ## Installing
 


### PR DESCRIPTION
Fixed a bug where creating many models would create identical models. Issue was that it created one model, then changed that ones values which resulted in duplicates.